### PR TITLE
fix: 🐛 pagination missing items due to Math.round

### DIFF
--- a/pages/expenses/monthly.tsx
+++ b/pages/expenses/monthly.tsx
@@ -132,7 +132,7 @@ export const getServerSideProps: GetServerSideProps<{
 
   expensesQuery = expensesQuery.range(rangeFrom, rangeTo);
   const { data: expensesData, count: expensesDataCount } = await expensesQuery;
-  const maxPageNum = Math.round((expensesDataCount ?? 0) / PAGE_LIMIT);
+  const maxPageNum = Math.ceil((expensesDataCount ?? 0) / PAGE_LIMIT);
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: GetServerSideProps<{
     .range(rangeFrom, rangeTo);
 
   const { data: expensesData, count: expensesDataCount } = await expensesQuery;
-  const maxPageNum = Math.round((expensesDataCount ?? 0) / PAGE_LIMIT);
+  const maxPageNum = Math.ceil((expensesDataCount ?? 0) / PAGE_LIMIT);
 
   return {
     props: {


### PR DESCRIPTION
use Math.ceil instead